### PR TITLE
Updated JobCard.fxml

### DIFF
--- a/src/main/resources/view/JobCard.fxml
+++ b/src/main/resources/view/JobCard.fxml
@@ -18,13 +18,13 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
 
-      <HBox spacing="0.5" alignment="CENTER_LEFT">
+      <HBox spacing="0.5" alignment="TOP_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="description" text="\$description" styleClass="cell_big_label" />
+        <Label fx:id="description" text="\$description" styleClass="cell_big_label" wrapText="true" />
       </HBox>
 
       <Label fx:id="status" styleClass="cell_small_label" text="Status: \$status" />


### PR DESCRIPTION
Fix #201 

Changed JobCard.fxml such that the job desc will overflow if there is insufficient width to view it
Also changed the index alignment such that it aligns to the TOP_LEFT rather than CENTER_LEFT.
<img width="947" height="420" alt="image" src="https://github.com/user-attachments/assets/f3024a21-dfb6-41a2-99a2-1dd1d17c7a88" />

<img width="1280" height="796" alt="image" src="https://github.com/user-attachments/assets/e9ee80f1-a7a8-41d3-8125-2b0469b235e3" />

